### PR TITLE
部署名のカラムのみ表示

### DIFF
--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -22,8 +22,13 @@ public class HomeController : Controller
 
     public async Task<IActionResult> Index()
     {
-        var employees = await _context.Employees.ToListAsync();
-        return View(employees);
+        var employees = await _context.Employees
+            .Include(e => e.Departments)
+            // .Include(e => e.Companies)
+            .Include(e => e.Divisions)
+            .Include(e => e.Licenses)
+            .ToListAsync();
+            return View(employees);
     }
 
     public IActionResult Privacy()

--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -68,9 +68,9 @@ public partial class ApplicationDbContext : DbContext
 							.HasDefaultValueSql("CURRENT_TIMESTAMP")
 							.HasColumnType("timestamp")
 							.HasColumnName("created_at");
-			entity.Property(e => e.DapartmentName)
+			entity.Property(e => e.DepartmentName)
 							.HasMaxLength(200)
-							.HasColumnName("dapartment_name");
+							.HasColumnName("department_name");
 			entity.Property(e => e.UpdatedAt)
 							.ValueGeneratedOnAddOrUpdate()
 							.HasDefaultValueSql("CURRENT_TIMESTAMP")

--- a/Models/Department.cs
+++ b/Models/Department.cs
@@ -9,7 +9,7 @@ public partial class Department
 
     public int CompanyId { get; set; }
 
-    public string DapartmentName { get; set; } = null!;
+    public string DepartmentName { get; set; } = null!;
 
     public DateTime? CreatedAt { get; set; }
 

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -18,11 +18,15 @@
             </tr>
         </thead>
         <tbody>
-            @foreach (var employee in Model)
+            @foreach (var employees in Model)
             {
                 <tr>
-                    <td>@employee.Id</td>
-                    <td>@employee.EmployeeName</td>
+                    <td>@employees.Id</td>
+                    <td>@employees.EmployeeName</td>
+                    <td>@string.Join(", ", employees.Departments.Select(d => d.DepartmentName))</td>
+                    <td>@employees.EmployeeName</td>
+                    <td>@employees.EmployeeName</td>
+                    <td>@employees.EmployeeName</td>
                 </tr>
             }
         </tbody>


### PR DESCRIPTION
## 概要
一覧ページに部署名を表示

## やったこと

```
一覧表示に部署名も表示させるため、
.includeを使い、ほかのDBも追加。

public async Task<IActionResult> Index()
    {
        var employees = await _context.Employees
            .Include(e => e.Departments)
            // .Include(e => e.Companies)
            .Include(e => e.Divisions)
            .Include(e => e.Licenses)
            .ToListAsync();
            return View(employees);
    }
```



## やらないこと
課名、資格、登録日は未実装。
